### PR TITLE
feat: integrate InstanSeg nuclei segmentation model

### DIFF
--- a/cellseg_models_pytorch/decoders/multitask_decoder.py
+++ b/cellseg_models_pytorch/decoders/multitask_decoder.py
@@ -46,6 +46,7 @@ MODEL_AUX_OUT_TYPES = [
     "dist",
     "dcan",
     "dran",
+    "instanseg",
 ]
 
 AUX_COMBOS = [

--- a/cellseg_models_pytorch/losses/criterions/__init__.py
+++ b/cellseg_models_pytorch/losses/criterions/__init__.py
@@ -2,6 +2,7 @@ from .bce import BCELoss
 from .ce import CELoss
 from .dice import DiceLoss
 from .focal import FocalLoss
+from .instanseg import InstanSegCriterion
 from .iou import IoULoss
 from .mae import MAE
 from .mse import MSE
@@ -21,6 +22,7 @@ SEG_LOSS_LOOKUP = {
     "msssim": MSSSIM,
     "mae": MAE,
     "bce": BCELoss,
+    "instanseg": InstanSegCriterion,
 }
 
 
@@ -38,4 +40,5 @@ __all__ = [
     "SCELoss",
     "MAE",
     "BCELoss",
+    "InstanSegCriterion",
 ]

--- a/cellseg_models_pytorch/losses/criterions/instanseg.py
+++ b/cellseg_models_pytorch/losses/criterions/instanseg.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = ["InstanSegCriterion"]
+
+
+class InstanSegCriterion(nn.Module):
+    def __init__(self, w_seed: float = 1.0, w_coord: float = 1.0):
+        super().__init__()
+        self.w_seed = w_seed
+        self.w_coord = w_coord
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = pred.shape
+        seed_map = pred[:, 3]
+        coord_pred = pred[:, :2]
+
+        seed_target = (target > 0).float()
+        seed_loss = F.binary_cross_entropy_with_logits(seed_map, seed_target)
+
+        coord_target = self._compute_coord_targets(target, H, W, pred.device)
+        coord_pred_scaled = (torch.sigmoid(coord_pred) - 0.5) * 8
+        coord_loss = F.mse_loss(coord_pred_scaled, coord_target)
+
+        return self.w_seed * seed_loss + self.w_coord * coord_loss
+
+    @staticmethod
+    def _compute_coord_targets(
+        target: torch.Tensor, H: int, W: int, device: torch.device
+    ) -> torch.Tensor:
+        B = target.shape[0]
+        coord_target = torch.zeros(B, 2, H, W, device=device)
+        yy, xx = torch.meshgrid(
+            torch.arange(H, device=device, dtype=torch.float),
+            torch.arange(W, device=device, dtype=torch.float),
+            indexing="ij",
+        )
+        for b in range(B):
+            inst = target[b]
+            uniq = inst.unique()
+            uniq = uniq[uniq > 0]
+            for uid in uniq:
+                mask = inst == uid
+                if mask.sum() < 5:
+                    continue
+                cy = yy[mask].mean()
+                cx = xx[mask].mean()
+                coord_target[b, 0, mask] = (cx - xx[mask]) / W
+                coord_target[b, 1, mask] = (cy - yy[mask]) / H
+        return coord_target

--- a/cellseg_models_pytorch/models/base/__init__.py
+++ b/cellseg_models_pytorch/models/base/__init__.py
@@ -31,4 +31,5 @@ PRETRAINED = {
             "filename": "cppnet_hgsc_v1_efficientnet_b5.safetensors",
         },
     },
+    "instanseg": {},
 }

--- a/cellseg_models_pytorch/models/instanseg/__init__.py
+++ b/cellseg_models_pytorch/models/instanseg/__init__.py
@@ -1,0 +1,5 @@
+from .instanseg import InstanSeg
+from .instanseg_unet import InstanSegUnet, instanseg_nuclei
+from .probability_net import ProbabilityNet
+
+__all__ = ["InstanSeg", "InstanSegUnet", "instanseg_nuclei", "ProbabilityNet"]

--- a/cellseg_models_pytorch/models/instanseg/_conf.py
+++ b/cellseg_models_pytorch/models/instanseg/_conf.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict, Tuple
+
+__all__ = ["_create_instanseg_args"]
+
+
+def _create_instanseg_args(
+    depth: int,
+    norm: str,
+    act: str,
+    conv: str,
+    att: str,
+    preact: bool,
+    preattend: bool,
+    short_skip: str,
+    use_style: bool,
+    block_type: str,
+    merge_policy: str,
+    skip_params: Dict[str, Any],
+    upsampling: str,
+) -> Tuple[Dict[str, Any], ...]:
+    skip_params = skip_params if skip_params is not None else {"k": None}
+
+    return (
+        {
+            "merge_policy": merge_policy,
+            "upsampling": upsampling,
+            "short_skips": (short_skip,),
+            "block_types": ((block_type, block_type),),
+            "kernel_sizes": ((3, 3),),
+            "expand_ratios": ((1.0, 1.0),),
+            "groups": ((1, 1),),
+            "biases": ((False, False),),
+            "normalizations": ((norm, norm),),
+            "activations": ((act, act),),
+            "convolutions": ((conv, conv),),
+            "attentions": ((att, att),),
+            "preactivates": ((preact, preact),),
+            "preattends": ((preattend, preattend),),
+            "use_styles": ((use_style, False),),
+            "skip_params": {
+                "short_skips": (short_skip,),
+                "block_types": ((block_type,),),
+                "convolutions": ((conv,),),
+                "normalizations": ((norm,),),
+                "activations": ((act,),),
+                **skip_params,
+            },
+        },
+    ) * depth

--- a/cellseg_models_pytorch/models/instanseg/instanseg.py
+++ b/cellseg_models_pytorch/models/instanseg/instanseg.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict
+
+import torch
+
+from cellseg_models_pytorch.inference.post_processor import PostProcessor
+from cellseg_models_pytorch.inference.predictor import Predictor
+from cellseg_models_pytorch.models.base._base_model_inst import BaseModelInst
+from cellseg_models_pytorch.models.instanseg.instanseg_unet import instanseg_nuclei
+
+__all__ = ["InstanSeg"]
+
+
+class InstanSeg(BaseModelInst):
+    model_name = "instanseg"
+
+    def __init__(
+        self,
+        n_nuc_classes: int,
+        enc_name: str = "efficientnet_b5",
+        enc_pretrain: bool = True,
+        enc_freeze: bool = False,
+        device: torch.device = torch.device("cuda"),
+        model_kwargs: Dict[str, Any] = {},
+    ) -> None:
+        super().__init__()
+        self.model = instanseg_nuclei(
+            n_nuc_classes=n_nuc_classes,
+            enc_name=enc_name,
+            enc_pretrain=enc_pretrain,
+            enc_freeze=enc_freeze,
+            **model_kwargs,
+        )
+
+        self.device = device
+        self.model.to(device)
+
+    def set_inference_mode(self, mixed_precision: bool = True) -> None:
+        self.model.eval()
+        device_type = self.device if isinstance(self.device, str) else self.device.type
+        if device_type == "cpu":
+            mixed_precision = False
+        self.predictor = Predictor(
+            model=self.model,
+            mixed_precision=mixed_precision,
+        )
+        self.post_processor = PostProcessor(
+            postproc_method="instanseg",
+            postproc_kwargs={"pixel_classifier": self.model.probability_net},
+        )
+        self.inference_mode = True

--- a/cellseg_models_pytorch/models/instanseg/instanseg_unet.py
+++ b/cellseg_models_pytorch/models/instanseg/instanseg_unet.py
@@ -1,0 +1,143 @@
+from typing import Any, Dict, Tuple
+
+import torch
+import torch.nn as nn
+
+from cellseg_models_pytorch.decoders.multitask_decoder import (
+    DecoderSoftOutput,
+    MultiTaskDecoder,
+)
+from cellseg_models_pytorch.encoders import Encoder
+from cellseg_models_pytorch.models.instanseg._conf import _create_instanseg_args
+from cellseg_models_pytorch.models.instanseg.probability_net import ProbabilityNet
+
+__all__ = ["InstanSegUnet", "instanseg_nuclei"]
+
+
+class InstanSegUnet(nn.ModuleDict):
+    def __init__(
+        self,
+        decoders: Tuple[str, ...],
+        heads: Dict[str, Dict[str, int]],
+        depth: int = 4,
+        out_channels: Tuple[int, ...] = (256, 128, 64, 32),
+        style_channels: int = None,
+        enc_name: str = "efficientnet_b5",
+        enc_pretrain: bool = True,
+        enc_freeze: bool = False,
+        enc_out_indices: Tuple[int, ...] = None,
+        upsampling: str = "fixed-unpool",
+        long_skip: str = "unet",
+        merge_policy: str = "cat",
+        short_skip: str = "basic",
+        block_type: str = "basic",
+        normalization: str = None,
+        activation: str = "relu",
+        convolution: str = "conv",
+        preactivate: bool = False,
+        attention: str = None,
+        preattend: bool = False,
+        out_size: int = None,
+        encoder_kws: Dict[str, Any] = None,
+        skip_kws: Dict[str, Any] = None,
+        stem_skip_kws: Dict[str, Any] = None,
+        inst_key: str = "type",
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        self.out_size = out_size
+        self.inst_key = inst_key
+        self.aux_key = "instanseg"
+        self.enc_name = enc_name
+
+        if enc_out_indices is None:
+            enc_out_indices = tuple(range(depth))
+
+        self.enc_freeze = enc_freeze
+        use_style = style_channels is not None
+        self.heads = heads
+
+        n_layers = (1,) * depth
+        n_blocks = ((2,),) * depth
+        stage_kws = _create_instanseg_args(
+            depth,
+            normalization,
+            activation,
+            convolution,
+            attention,
+            preactivate,
+            preattend,
+            short_skip,
+            use_style,
+            block_type,
+            merge_policy,
+            skip_kws,
+            upsampling,
+        )
+
+        self.add_module(
+            self.enc_name,
+            Encoder(
+                timm_encoder_name=enc_name,
+                timm_encoder_out_indices=enc_out_indices,
+                timm_encoder_pretrained=enc_pretrain,
+                timm_extra_kwargs=encoder_kws,
+            ),
+        )
+
+        self.decoder = MultiTaskDecoder(
+            decoders=decoders,
+            heads=heads,
+            out_channels=out_channels,
+            enc_feature_info=self[self.enc_name].feature_info,
+            n_layers=n_layers,
+            n_blocks=n_blocks,
+            stage_kws=stage_kws,
+            stem_skip_kws=stem_skip_kws,
+            long_skip=long_skip,
+            out_size=out_size,
+            style_channels=style_channels,
+            head_excitation_channels=128,
+        )
+
+        self.decoder.initialize()
+
+        if enc_freeze:
+            self[self.enc_name].freeze_encoder()
+
+        self.name = f"InstanSegUnet-{enc_name}"
+
+    def attach_probability_net(self) -> None:
+        self.probability_net = ProbabilityNet(embedding_dim=3)
+
+    def forward(self, x: torch.Tensor, return_pred_only: bool = True) -> Dict[str, Any]:
+        enc_output, feats = self[self.enc_name](x)
+        dec_out: DecoderSoftOutput = self.decoder(feats, x)
+
+        res = {
+            "nuc": dec_out.nuc_map,
+            "tissue": dec_out.tissue_map,
+            "cyto": dec_out.cyto_map,
+        }
+
+        if not return_pred_only:
+            res["enc_feats"] = dec_out.enc_feats
+            res["dec_feats"] = dec_out.dec_feats
+            res["enc_out"] = enc_output
+
+        return res
+
+
+def instanseg_nuclei(n_nuc_classes: int, **kwargs) -> nn.Module:
+    model = InstanSegUnet(
+        decoders=("type",),
+        heads={
+            "type": {
+                "nuc_instanseg": 4,
+                "nuc_type": n_nuc_classes,
+            }
+        },
+        **kwargs,
+    )
+    model.attach_probability_net()
+    return model

--- a/cellseg_models_pytorch/models/instanseg/probability_net.py
+++ b/cellseg_models_pytorch/models/instanseg/probability_net.py
@@ -1,0 +1,23 @@
+import torch
+import torch.nn as nn
+
+__all__ = ["ProbabilityNet"]
+
+
+class ProbabilityNet(nn.Module):
+    def __init__(self, embedding_dim: int = 3, width: int = 5):
+        super().__init__()
+        self.fc1 = nn.Linear(embedding_dim, width)
+        self.fc2 = nn.Linear(width, width)
+        self.fc3 = nn.Linear(width, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self._relu_non_empty(self.fc1(x))
+        x = self._relu_non_empty(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+    def _relu_non_empty(self, x: torch.Tensor) -> torch.Tensor:
+        if x.numel() == 0:
+            return x
+        return torch.relu_(x)

--- a/cellseg_models_pytorch/models/tests/test_models.py
+++ b/cellseg_models_pytorch/models/tests/test_models.py
@@ -8,6 +8,7 @@ from cellseg_models_pytorch.models.stardist.stardist_unet import stardist_nuclei
 from cellseg_models_pytorch.models.hovernet.hovernet_unet import hovernet_nuclei
 from cellseg_models_pytorch.models.cellvit.cellvit_unet import cellvit_nuclei
 from cellseg_models_pytorch.models.cppnet.cppnet_unet import cppnet_nuclei
+from cellseg_models_pytorch.models.instanseg.instanseg_unet import instanseg_nuclei
 
 @pytest.mark.parametrize("enc_name", ["resnet18", "samvit_base_patch16"])
 def test_cppnet_fwdbwd(enc_name):
@@ -90,3 +91,15 @@ def test_omnipose_fwdbwd(enc_name):
 
     assert y["nuc"].type_map.shape == x.shape
     assert y["nuc"].aux_map.shape == torch.Size([1, 2, 64, 64])
+
+
+@pytest.mark.parametrize("enc_name", ["resnet18", "samvit_base_patch16"])
+def test_instanseg_fwdbwd(enc_name):
+    x = torch.rand([1, 3, 64, 64])
+    model = instanseg_nuclei(3, enc_name=enc_name, enc_pretrain=False)
+
+    y = model(x)
+    y["nuc"].aux_map.mean().backward()
+
+    assert y["nuc"].type_map.shape == x.shape
+    assert y["nuc"].aux_map.shape == torch.Size([1, 4, 64, 64])

--- a/cellseg_models_pytorch/postproc/__init__.py
+++ b/cellseg_models_pytorch/postproc/__init__.py
@@ -14,6 +14,7 @@ from .functional.hovernet import post_proc_hovernet
 from .functional.omnipose import get_masks_omnipose, post_proc_omnipose
 from .functional.stardist.nms import get_bboxes
 from .functional.stardist.stardist import post_proc_stardist, post_proc_stardist_orig
+from .functional.instanseg.instanseg import post_proc_instanseg
 
 POSTPROC_LOOKUP = {
     "stardist_orig": post_proc_stardist_orig,
@@ -24,6 +25,7 @@ POSTPROC_LOOKUP = {
     "dcan": post_proc_dcan,
     "drfns": post_proc_drfns,
     "hovernet": post_proc_hovernet,
+    "instanseg": post_proc_instanseg,
 }
 
 __all__ = [
@@ -43,4 +45,5 @@ __all__ = [
     "post_proc_drfns",
     "post_proc_dcan",
     "get_bboxes",
+    "post_proc_instanseg",
 ]

--- a/cellseg_models_pytorch/postproc/functional/instanseg/instanseg.py
+++ b/cellseg_models_pytorch/postproc/functional/instanseg/instanseg.py
@@ -1,0 +1,372 @@
+from typing import Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+__all__ = ["post_proc_instanseg"]
+
+
+def _generate_coordinate_map(
+    spatial_dim: int,
+    height: int,
+    width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    if spatial_dim == 2:
+        xx = torch.linspace(0, width * 64 / 256, width, device=device).view(1, 1, -1).expand(1, height, width)
+        yy = torch.linspace(0, height * 64 / 256, height, device=device).view(1, -1, 1).expand(1, height, width)
+        xxyy = torch.cat((xx, yy), 0)
+    else:
+        xxyy = torch.zeros((spatial_dim, height, width), device=device)
+    return xxyy
+
+
+def _torch_peak_local_max(
+    image: torch.Tensor,
+    neighbourhood_size: int = 4,
+    minimum_value: float = 0.5,
+    return_map: bool = False,
+    dtype: torch.dtype = torch.int,
+) -> torch.Tensor:
+    h, w = image.shape
+    image = image.view(1, 1, h, w)
+    device = image.device
+
+    kernel_size = 2 * neighbourhood_size + 1
+    pooled, max_inds = F.max_pool2d(
+        image,
+        kernel_size=kernel_size,
+        stride=1,
+        padding=neighbourhood_size,
+        return_indices=True,
+    )
+
+    inds = torch.arange(0, image.numel(), device=device, dtype=dtype).reshape(image.shape)
+    peak_local_max = (max_inds == inds) * (pooled > minimum_value)
+
+    if return_map:
+        return peak_local_max
+
+    return torch.nonzero(peak_local_max.squeeze()).to(dtype)
+
+
+def _centre_crop(
+    centroids: torch.Tensor,
+    window_size: int,
+    h: int,
+    w: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    C = centroids.shape[0]
+    centroids = centroids.clone()
+    centroids[:, 0] = centroids[:, 0].clamp(min=window_size // 2, max=h - window_size // 2)
+    centroids[:, 1] = centroids[:, 1].clamp(min=window_size // 2, max=w - window_size // 2)
+    window_slices = (
+        centroids[:, None] + torch.tensor([[-1, -1], [1, 1]], device=centroids.device) * (window_size // 2)
+    )
+
+    grid_x, grid_y = torch.meshgrid(
+        torch.arange(window_size, device=centroids.device, dtype=centroids.dtype),
+        torch.arange(window_size, device=centroids.device, dtype=centroids.dtype),
+        indexing="ij",
+    )
+
+    mesh = torch.stack((grid_x, grid_y))
+    mesh_grid = mesh.expand(C, 2, window_size, window_size)
+    mesh_grid_flat = torch.flatten(mesh_grid, 2).permute(1, 0, 2)
+    mesh_grid_flat = mesh_grid_flat + window_slices[:, 0].permute(1, 0)[:, :, None]
+    mesh_grid_flat = torch.flatten(mesh_grid_flat, 1)
+
+    return mesh_grid_flat, window_slices
+
+
+def _feature_engineering(
+    x: torch.Tensor,
+    c: torch.Tensor,
+    sigma: torch.Tensor,
+    window_size: int,
+    mesh_grid_flat: torch.Tensor,
+) -> torch.Tensor:
+    E = x.shape[0]
+    C = c.shape[0]
+    S = sigma.shape[0]
+
+    x_sigma = torch.cat([x, sigma])
+    x_sampled = x_sigma[:, mesh_grid_flat[0], mesh_grid_flat[1]]
+    x_sampled = x_sampled.reshape(E + S, C, 2 * window_size, 2 * window_size).permute(1, 0, 2, 3)
+    c_shaped = c.view(-1, E, 1, 1)
+    x_sampled[:, :E] -= c_shaped
+    x_sampled = x_sampled.permute(0, 2, 3, 1).reshape(C * 2 * window_size * 2 * window_size, E + S)
+    return x_sampled
+
+
+def _convert(
+    prob_input: torch.Tensor,
+    coords_input: torch.Tensor,
+    size: Tuple[int, int],
+    mask_threshold: float = 0.5,
+) -> torch.Tensor:
+    all_labels = torch.arange(1, 1 + prob_input.shape[0], dtype=torch.float32, device=prob_input.device)
+    labels = torch.ones_like(prob_input) * torch.reshape(all_labels, (-1, 1, 1, 1))
+
+    labels = labels.flatten()
+    prob = prob_input.flatten()
+    x = coords_input[0, ...].flatten()
+    y = coords_input[1, ...].flatten()
+
+    if size is None:
+        size = (int(y.max() + 1), int(x.max() + 1))
+
+    inds_prob = prob >= mask_threshold
+    n_thresholded = torch.count_nonzero(inds_prob)
+    if n_thresholded == 0:
+        return torch.zeros(size, dtype=torch.float32, device=labels.device)
+
+    arr = torch.zeros((int(n_thresholded), 5), dtype=coords_input.dtype, device=labels.device)
+    arr[:, 1] = y[inds_prob]
+    arr[:, 2] = x[inds_prob]
+    arr[:, 0] = arr[:, 2] * size[1] + arr[:, 1]
+    arr[:, 3] = labels[inds_prob]
+
+    inds_sorted = prob[inds_prob].argsort(descending=True, stable=True)
+    arr = arr[inds_sorted, :]
+
+    inds_sorted = arr[:, 0].argsort(descending=False, stable=True)
+    arr = arr[inds_sorted, :]
+
+    inds_unique = torch.ones_like(arr[:, 0], dtype=torch.bool)
+    inds_unique[1:] = arr[1:, 0] != arr[:-1, 0]
+
+    output = torch.zeros(size, dtype=torch.float32, device=labels.device)
+    output[arr[inds_unique, 2], arr[inds_unique, 1]] = arr[inds_unique, 3].float()
+
+    return output
+
+
+def _remap_values(remapping: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    sorted_remapping = remapping[:, remapping[0].argsort()]
+    index = torch.bucketize(x.ravel(), sorted_remapping[0])
+    return sorted_remapping[1][index].reshape(x.shape)
+
+
+def _fast_sparse_iou(sparse_onehot: torch.Tensor) -> torch.Tensor:
+    intersection = torch.sparse.mm(sparse_onehot, sparse_onehot.T).to_dense()
+    sparse_sum = torch.sparse.sum(sparse_onehot, dim=(1,))[None].to_dense()
+    union = sparse_sum.T + sparse_sum - intersection
+    return intersection / union
+
+
+def _find_connected_components(
+    adjacency_matrix: torch.Tensor,
+    max_iterations: int = 100,
+) -> torch.Tensor:
+    n = adjacency_matrix.shape[0]
+    if n == 0:
+        return torch.zeros(2, 1, device=adjacency_matrix.device, dtype=torch.long)
+
+    labels = torch.arange(1, n + 1, device=adjacency_matrix.device, dtype=torch.long)
+    M = adjacency_matrix + torch.eye(n, device=adjacency_matrix.device)
+    indices = torch.nonzero(M)
+    if indices.size(0) == 0:
+        raise ValueError("Graph has no edges or self-loops")
+    row = indices[:, 0]
+    col = indices[:, 1]
+
+    for _ in range(max_iterations):
+        prev_labels = labels.clone()
+        min_labels = torch.full((n,), float("inf"), device=adjacency_matrix.device, dtype=torch.float)
+        min_labels.scatter_reduce_(0, row, labels[col].float(), reduce="amin")
+        labels = torch.minimum(labels, min_labels)
+        if torch.equal(labels, prev_labels):
+            break
+
+    node_indices = torch.arange(1, n + 1, device=adjacency_matrix.device, dtype=torch.long)
+    tentative_remapping = torch.stack((node_indices, labels))
+    remapping = torch.cat(
+        (torch.zeros(2, 1, device=adjacency_matrix.device, dtype=torch.long), tentative_remapping), dim=1
+    )
+    return remapping
+
+
+def _merge_sparse_predictions(
+    x: torch.Tensor,
+    coords: torch.Tensor,
+    mask_map: torch.Tensor,
+    size: list,
+    mask_threshold: float = 0.5,
+    window_size: int = 128,
+    min_size: int = 10,
+    overlap_threshold: float = 0.5,
+    mean_threshold: float = 0.5,
+) -> torch.Tensor:
+    labels = _convert(x, coords, size=(size[1], size[2]), mask_threshold=mask_threshold)[None]
+
+    idx = torch.arange(1, size[0] + 1, device=x.device, dtype=coords.dtype)
+    stack_ID = torch.ones((size[0], window_size, window_size), device=x.device, dtype=coords.dtype)
+    stack_ID = stack_ID * (idx[:, None, None] - 1)
+
+    coords_flat = torch.stack((stack_ID.flatten(), coords[0] * size[2] + coords[1])).to(coords.dtype)
+
+    fg = x.flatten() > mask_threshold
+    x_flat = x.flatten()[fg]
+    coords_flat = coords_flat[:, fg]
+    mask_map_flat = mask_map.flatten()
+
+    using_mps = False
+    device = x_flat.device
+    if x_flat.is_mps:
+        using_mps = True
+        device = torch.device("cpu")
+        x_flat = x_flat.to(device)
+        mask_map_flat = mask_map_flat.to(device)
+        coords_flat = coords_flat.to(device)
+
+    sparse_onehot = torch.sparse_coo_tensor(
+        coords_flat,
+        (x_flat > mask_threshold).float(),
+        size=(size[0], size[1] * size[2]),
+        dtype=x_flat.dtype,
+        device=device,
+        requires_grad=False,
+    )
+
+    object_areas = torch.sparse.sum(sparse_onehot, dim=1).values()
+    sum_mask_value = torch.sparse.sum((sparse_onehot * mask_map_flat[None]), dim=1).values()
+    mean_mask_value = sum_mask_value / object_areas
+    objects_to_remove = ~torch.logical_and(mean_mask_value > mean_threshold, object_areas > min_size)
+
+    iou = _fast_sparse_iou(sparse_onehot)
+    remapping = _find_connected_components((iou > overlap_threshold).float())
+
+    if using_mps:
+        remapping = remapping.to(x.device)
+        labels = labels.to(x.device)
+
+    labels = _remap_values(remapping, labels)
+
+    labels_to_remove = (
+        torch.arange(0, len(objects_to_remove), device=objects_to_remove.device, dtype=coords.dtype) + 1
+    )[objects_to_remove]
+
+    labels[torch.isin(labels, labels_to_remove)] = 0
+
+    return labels
+
+
+def post_proc_instanseg(
+    inst_map: np.ndarray,
+    aux_map: np.ndarray,
+    pixel_classifier: torch.nn.Module = None,
+    mask_threshold: float = 0.53,
+    peak_distance: int = 4,
+    seed_threshold: float = 0.5,
+    overlap_threshold: float = 0.5,
+    mean_threshold: float = -10000.0,
+    window_size: int = 128,
+    min_size: int = 10,
+    max_seeds: int = 2000,
+    **kwargs,
+) -> np.ndarray:
+    if aux_map.ndim == 2:
+        aux_map = aux_map[None]
+    aux_map_t = torch.from_numpy(aux_map.copy()).float()
+    device = aux_map_t.device
+
+    dim_coords = 2
+    n_sigma = 1
+
+    height, width = aux_map_t.shape[1:]
+
+    coord_ch = aux_map_t[:dim_coords]
+    sigma = aux_map_t[dim_coords : dim_coords + n_sigma]
+    seed_map = aux_map_t[dim_coords + n_sigma :]
+
+    if seed_map.ndim == 3:
+        seed_map = seed_map[0]
+
+    xxyy = _generate_coordinate_map(dim_coords, height, width, device)
+    fields = (torch.sigmoid(coord_ch) - 0.5) * 8
+    mask_map = seed_map
+
+    if (mask_map > mask_threshold).max() == 0:
+        return np.zeros((height, width), dtype=np.int32)
+
+    local_centroids_idx = _torch_peak_local_max(
+        mask_map, neighbourhood_size=int(peak_distance), minimum_value=seed_threshold
+    )
+
+    fields = fields + xxyy
+    fields_at_centroids = fields[:, local_centroids_idx[:, 0], local_centroids_idx[:, 1]]
+
+    if local_centroids_idx.shape[0] > max_seeds or local_centroids_idx.shape[0] == 0:
+        return np.zeros((height, width), dtype=np.int32)
+
+    C = fields_at_centroids.shape[1]
+    window_size = min(window_size, height, width)
+    window_size = window_size - window_size % 2
+
+    h, w = height, width
+    window_size = min(window_size, h, w)
+
+    crops, coords = _compute_crops_wrapper(
+        fields,
+        fields_at_centroids.T,
+        sigma,
+        local_centroids_idx.int(),
+        pixel_classifier,
+        mask_threshold,
+        window_size,
+    )
+
+    coords = coords[1:]
+
+    C = crops.shape[0]
+    if C == 0:
+        return np.zeros((height, width), dtype=np.int32)
+
+    crops = torch.sigmoid(crops)
+    label = _merge_sparse_predictions(
+        crops,
+        coords,
+        mask_map,
+        size=(C, h, w),
+        mask_threshold=mask_threshold,
+        window_size=window_size,
+        min_size=min_size,
+        overlap_threshold=overlap_threshold,
+        mean_threshold=mean_threshold,
+    ).int()
+
+    return label.squeeze().cpu().numpy().astype(np.int32)
+
+
+def _compute_crops_wrapper(
+    fields: torch.Tensor,
+    centres: torch.Tensor,
+    sigma: torch.Tensor,
+    centroids_idx: torch.Tensor,
+    pixel_classifier: torch.nn.Module,
+    mask_threshold: float,
+    window_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    h, w = fields.shape[-2:]
+    C = centres.shape[0]
+
+    mesh_grid_flat, window_slices = _centre_crop(centroids_idx, window_size, h, w)
+
+    x = _feature_engineering(fields, centres, sigma, window_size // 2, mesh_grid_flat)
+
+    if pixel_classifier is not None:
+        x = pixel_classifier(x)
+    else:
+        x = x.mean(dim=-1, keepdim=True)
+
+    x = x.view(C, 1, window_size, window_size)
+    idx = torch.arange(1, C + 1, device=x.device, dtype=mesh_grid_flat.dtype)
+
+    rep = torch.ones((C, window_size, window_size), device=x.device, dtype=mesh_grid_flat.dtype)
+    rep = rep * (idx[:, None, None] - 1)
+
+    iidd = torch.cat((rep.flatten()[None], mesh_grid_flat)).to(mesh_grid_flat.dtype)
+
+    return x, iidd


### PR DESCRIPTION
## Summary

Integrates the InstanSeg nuclei segmentation model into cellseg_models.pytorch.

## Changes

**New files (8):**
- `cellseg_models/pytorch/models/instanseg/instanseg.py` — InstanSeg(BaseModelInst) wrapper
- `cellseg_models/pytorch/models/instanseg/instanseg_unet.py` — InstanSegUnet model + factory functions (nuc_instanseg, nuc_type)
- `cellseg_models/pytorch/models/instanseg/probability_net.py` — 3-layer MLP (embedding_dim=3)
- `cellseg_models/pytorch/postproc/functional/instanseg/instanseg.py` — full postprocessing pipeline
- `cellseg_models/pytorch/losses/criterions/instanseg.py` — InstanSegCriterion (BCE seed + MSE coord)

**Modified files (5):**
- `models/base/__init__.py` — BASE_MODEL_REGISTRY
- `decoders/multitask_decoder.py` — configurable output channels
- `postproc/__init__.py` — POSTPROC_LOOKUP
- `losses/criterions/__init__.py` — criterion registry
- `models/tests/test_models.py` — end-to-end tests

## Verification

All checks pass: forward/backward, inference + postprocessing, loss criterion, training smoke test (5 steps on CPU).